### PR TITLE
Fixed error of data type mismatch in loss function

### DIFF
--- a/models/deepcrack_model.py
+++ b/models/deepcrack_model.py
@@ -98,6 +98,7 @@ class DeepCrackModel(BaseModel):
         lambda_fused = self.opt.lambda_fused
 
         self.loss_side = 0.0
+        self.label = self.label.float() 
         for out, w in zip(self.outputs[:-1], self.weight_side):
             #self.loss_side += self.criterionSeg(out, self.label3d) * w
             self.loss_side += self.criterionSeg(out, self.label) * w


### PR DESCRIPTION
I have tried to run your code using Pytorch 1.4.0 and found an error related to BCEWithLogitsLoss (), so I've fixed it and it works on PyTorch 1.4.0.